### PR TITLE
[fix] .img-error::after covering text

### DIFF
--- a/styles/index.scss
+++ b/styles/index.scss
@@ -392,6 +392,7 @@ button {
 .img-error {
   position: relative;
 }
+
 .img-error::after {
   content: 'Oops! Sorry, we cannot find the image.';
   display: flex;
@@ -402,12 +403,11 @@ button {
   text-align: center;
   font-size: 1.5rem;
   top: 0%;
-  height: 100%;
+  height: 85%;
   left: 50%;
   transform: translateX(-50%);
   max-width: 100%;
   background-color: black;
   color: white;
   width: 100%;
-
 }


### PR DESCRIPTION
Since the layout changed for Next Image component when updated, the text started to get covered by .img-error::after. Adjusted it's height to prevent overlap